### PR TITLE
Kleiner Verbesserungen im CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE Release)
 endif(NOT CMAKE_BUILD_TYPE)
 
-set(CMAKE_CXX_FLAGS "-Wall -Wextra -Wpedantic")
+set(CMAKE_CXX_FLAGS "-Wall -Wextra -Wpedantic -Werror")
 if (CMAKE_BUILD_TYPE STREQUAL "Debug")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=address -fno-omit-frame-pointer")
 endif ()

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -5,7 +5,7 @@ find_package(GTest)
 if (GTest_FOUND)
     include_directories(${GTEST_INCLUDE_DIR})
 
-    set(TEST_SOURCES SopraGameModel.cpp)
+    file(GLOB_RECURSE TEST_SOURCES . *.cpp)
 
     if (USE_INSTALLED_LIB)
         add_definitions(-DUSE_INSTALLED_LIB)
@@ -21,4 +21,6 @@ if (GTest_FOUND)
             NAME ${PROJECT_NAME}
             COMMAND ${PROJECT_NAME}
     )
+else()
+    message(WARNING "GTest not found, you won't be able to run the tests")
 endif()

--- a/sopraGameModel.cpp
+++ b/sopraGameModel.cpp
@@ -39,7 +39,7 @@ namespace gameModel{
             return x < 8 ? Cell::RestrictedLeft : Cell::RestrictedRight;
         } else if(x > 0 && x < 16 && y > 1 && y < 11){
             return x < 8 ? Cell::RestrictedLeft : Cell::RestrictedRight;
-        } else if(x >= 0 && y > 3 && y < 9){
+        } else if(y > 3 && y < 9){
             return x < 8 ? Cell::RestrictedLeft : Cell::RestrictedRight;
         } else{
             return Cell::OutOfBounds;


### PR DESCRIPTION
Alle *.cpp Files in Tests/ werden automatisch zum Test target hinzugefügt. Warnung wenn GTest nicht gefunden wurde.
Warning entfernt (unsigned int >= 0).